### PR TITLE
ADF-3525 Bump the WP and WC versions tested against

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: abletech
 Tags: address autocomplete, address validation, woocommerce, australia, new zealand
 Requires at least: 4.1
-Tested up to: 6.5.3
-WC tested up to: 8.5.1
+Tested up to: 6.6
+WC tested up to: 9.1.2
 Stable tag: 1.7.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
The new Vultr instances comes with latest WP (6.6) and WC (9.1.2) versions. The readme has been updated to reflect that.

No need for a release, this can ship in the next one.